### PR TITLE
グループをサイドバーに表示する

### DIFF
--- a/app/assets/stylesheets/modules/_side_bar.scss
+++ b/app/assets/stylesheets/modules/_side_bar.scss
@@ -39,6 +39,10 @@
   }*/
 }
 
+a {
+  text-decoration: none;
+}
+
 .group {
   padding: 20px 20px 40px;
   &__name {
@@ -52,5 +56,9 @@
     font-size: 11px;
     color: $white-color;
     /*padding-bottom: 40px;*/
+  }
+
+  &:hover {
+    background-color: #43546b;
   }
 }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,6 @@
 class GroupsController < ApplicationController
   def index
+    @mygroups = current_user.groups
   end
 
   def new

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,25 @@
+
+= render partial: 'shared/side_bar'
+
+.chat-main
+  .header
+    .header-group
+      .header-group__name sampleグループ
+      = link_to "Edit", "#", class: "header-group__edit-btn"
+    .header-group-members
+      MEMBER:
+      %i Sample_User
+  .main
+    .main__message-list
+      .main__message
+        .main__message__name Sample_User
+        .main__message__time 2019/01/15 12:00:00
+        .main__message__text テストメッセージ
+  .main__footer
+    %form.main__footer-form
+      .main__footer-body
+        %input.message{type: "text", placeholder: "type a message", name: "message[body]"}
+        %label.chat-file{for: "message_image"}
+          %input.image{type: "file", id: "message_image", name: "message[image]"}
+          %i.fa.fa-picture-o
+      %input.submit{type: "submit", value: "Send"}

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -7,12 +7,15 @@
         %i.fa.fa-edit
       = link_to edit_user_path(current_user), class: "cog" do
         %i.fa.fa-cog
-  .group
-    %h2.group__name サンプル
-    %p.group__new よろしくお願いします
-  .group
-    %h2.group__name サンプル2
-    %p.group__new テストテスト
-  .group
-    %h2.group__name sampleグループ
-    %p.group__new まだメッセージはありません
+  - current_user.groups.each do |group|
+    = link_to group_messages_path(group) do
+      .group
+        %h2.group__name= group.name
+        %p.group__new メッセージはまだありません。
+
+  / .group
+  /   %h2.group__name サンプル2
+  /   %p.group__new テストテスト
+  / .group
+  /   %h2.group__name sampleグループ
+  /   %p.group__new まだメッセージはありません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   #root 'groups#index'
-  root 'messages#index'
+  root 'groups#index'
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]


### PR DESCRIPTION
# WHAT
グループをサイドバーに表示する. このプルリクエストではまず以下を作成する 

**6. 作成したグループをサイドバーに表示する**
* 現在ログイン中のユーザーが所属するグループをサイドバーに表示するようにする

グループ機能の実装にあたり残りのタスクは以下
  
> 7. グループ編集機能を実装する
> 8. ルートパスを変更する

 
# WHY
chat-spaceではメッセージのやりとりをするためには、グループを作成する必要があるから.