### PR TITLE
メッセージ送信を非同期にする

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -19,13 +19,13 @@ $(function() {
                                 </div>` : "";
     let html = `<div class="main__message">
                   <div class="main__message__name">${message.user_name}</div>
-                  <div class="main__message__time">${getFormatDate(message.created_at)}</div>
+                  <div class="main__message__time">${message.created_at}</div>
                   ${content}
                   ${img}
                 </div>`;
     return html;
   }
-  //console.log("read!!");
+
   $('#new_message').on('submit', function(e) {
     e.preventDefault();
     var data = new FormData(this);
@@ -40,7 +40,6 @@ $(function() {
       contentType: false
     })
     .done(function(data) {
-      //console.log('posted ok!');
       let html = buildHTML(data);
       $('.main__message-list').append(html);
       // messageがある箇所をスクロール
@@ -49,8 +48,7 @@ $(function() {
     .fail(function(e) {
       alert('投稿に失敗しました');
     });
-    $('.message').val('');
-    $('#message_image').val('');
+    $(this)[0].reset();
 
     return false;
   });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,17 +1,4 @@
 $(function() {
-  function getFormatDate(date) {
-    var timestamp = Date.parse(date);
-    var d = new Date(timestamp);
-    var year = d.getFullYear();
-    var month = d.getMonth() + 1;
-    var day = d.getDate();
-    var hours = "0" + d.getHours();
-    var formattedHours = hours.slice(-2);
-    var minutes = d.getMinutes();
-    //var seconds = d.getSeconds();
-
-    return `${year}-${month}-${day}　${formattedHours}:${minutes}　`;
-  }
   function buildHTML(message) {
     let content = message.content ? `<div class="main__message__text">${message.content}</div>` : "";
     let img = message.image ? `<div class="main__message__image">

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,57 @@
+$(function() {
+  function getFormatDate(date) {
+    var timestamp = Date.parse(date);
+    var d = new Date(timestamp);
+    var year = d.getFullYear();
+    var month = d.getMonth() + 1;
+    var day = d.getDate();
+    var hours = "0" + d.getHours();
+    var formattedHours = hours.slice(-2);
+    var minutes = d.getMinutes();
+    //var seconds = d.getSeconds();
+
+    return `${year}-${month}-${day}　${formattedHours}:${minutes}　`;
+  }
+  function buildHTML(message) {
+    let content = message.content ? `<div class="main__message__text">${message.content}</div>` : "";
+    let img = message.image ? `<div class="main__message__image">
+                                <img src="${message.image}">
+                                </div>` : "";
+    let html = `<div class="main__message">
+                  <div class="main__message__name">${message.user_name}</div>
+                  <div class="main__message__time">${getFormatDate(message.created_at)}</div>
+                  ${content}
+                  ${img}
+                </div>`;
+    return html;
+  }
+  //console.log("read!!");
+  $('#new_message').on('submit', function(e) {
+    e.preventDefault();
+    var data = new FormData(this);
+    var url = $(this).attr('action');
+
+    $.ajax({
+      url: url,
+      type: 'POST',
+      data: data,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data) {
+      //console.log('posted ok!');
+      let html = buildHTML(data);
+      $('.main__message-list').append(html);
+      // messageがある箇所をスクロール
+      $('.main').animate({scrollTop: $('.main')[0].scrollHeight}, 'fast');
+    })
+    .fail(function(e) {
+      alert('投稿に失敗しました');
+    });
+    $('.message').val('');
+    $('#message_image').val('');
+
+    return false;
+  });
+});

--- a/app/assets/stylesheets/modules/_chat.scss
+++ b/app/assets/stylesheets/modules/_chat.scss
@@ -84,8 +84,13 @@
     }
 
     &__image {
-      width: 50%;
+      width: 100%;
       margin-bottom: 20px;
+
+      & img {
+        width: 80%;
+
+      }
     }
   }
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,12 +10,15 @@ class MessagesController < ApplicationController
 
   def create
     @message = @group.messages.new(message_params)
-    if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
-    else
-      @messages = @group.messages.includes(:user)
+    respond_to do |format|
+      if @message.save
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+        format.json
+      else
+        format.html { @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'
-      render :index
+        render :index}
+      end
     end
   end
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
-  %body
+  %body{"data-turbolinks": "false"}
     -# フラッシュメッセージの表示
     = render partial: 'layouts/flash'
     = yield

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,6 +1,6 @@
 .main__message
   .main__message__name= message.user.name
-  .main__message__time= simple_time(message.created_at)
+  .main__message__time= message.created_at.to_s
 - if message.content.present?
   .main__message__text= message.content
 - if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.content @message.content
+json.image @message.image.url
+json.created_at @message.created_at

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.user_name @message.user.name
 json.content @message.content
 json.image @message.image.url
-json.created_at @message.created_at
+json.created_at @message.created_at.to_s

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -4,12 +4,12 @@
 .chat-main
   .header
     .header-group
-      .header-group__name sampleグループ
+      .header-group__name= @group.name
       = link_to "Edit", edit_group_path(params[:group_id]), class: "header-group__edit-btn"
     .header-group-members
       MEMBER:
       - @members.each do |member|
-        %i #{member.name}　
+        %i #{member.name}
   .main
     .main__message-list
       = render partial: 'message', collection: @messages

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,6 @@ module ChatSpace
     end
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
-    config.time_zone = 'Asia/Tokyo'
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,9 @@
+Time::DATE_FORMATS[:default] = '%Y-%m-%d %H:%M'
+
+Time::DATE_FORMATS[:datetime] = '%Y-%m-%d %H:%M'
+
+Time::DATE_FORMATS[:date] = '%Y-%m-%d'
+
+Time::DATE_FORMATS[:time] = '%H:%M:%S'
+
+Date::DATE_FORMATS[:default] = '%Y-%m-%d'


### PR DESCRIPTION
# WHAT
現状はメッセージを入力後フォームを送信すると全てリロードしてメッセージが投稿される。  
これを非同期通信にして、フォームが送信されると投稿したメッセージをページ全体をリロードすることなく表示するようにする。


# WHY
非同期通信でメッセージを送信できるようにすることで、ユーザーが使いやすいものになるから。