### PR TITLE
ユーザー検索をインクリメンタルサーチ化

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,43 @@
+$(function() {
+  function appendUser(user) {
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${user.name}</p>
+                  <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</a>
+                </div>`;
+    $('#user-search-result').append(html);
+  }
+
+  function appendNoUser(text) {
+    var html = `<div class="chat-group-user clearfix">
+                  ${text}
+                </div>`;
+    $('#user-search-result').append(html);
+  }
+
+  $('#user-search-field').on('keyup', function() {
+    console.log($(this).val());
+    var input = $(this).val();
+
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { name: input },
+      dataType: 'json'
+    })
+    .done(function(users) {
+      console.log('ok');
+      console.log(users);
+      $('#user-search-result').empty();
+      if (users.length !== 0) {
+        users.forEach(function(user) {
+          appendUser(user);
+        });
+      } else {
+        appendNoUser("該当するユーザーはいません");
+      }
+    })
+    .fail(function() {
+      alert('ユーザーの検索に失敗しました');
+    });
+  });
+});

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -20,7 +20,7 @@ $(function() {
     var html = `<div class="chat-group-user clearfix js-chat-member" id="group-user-${id}">
                   <input name="group[user_ids][]" type="hidden" value="${id}">
                   <p class="chat-group-user__name">${name}</p>
-                  <a class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn">削除</a>
+                  <a class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn" data-user-id="${id}">削除</a>
                 </div>`;
     return html;
   }
@@ -35,6 +35,7 @@ $(function() {
 
   // 検索結果で表示された「追加」ボタンクリック時のイベント
   $('#user-search-result').on('click', '.user-search-add', function() {
+    $('#user-search-field').val('');
     var userId = $(this).attr('data-user-id');
     var userName = $(this).attr('data-user-name');
     $('#chat-group-users').append(buildHTML(userId, userName));

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,12 @@
 class UsersController < ApplicationController
 
+  def index
+    @users = User.where('name LIKE(?)', "%#{params[:name]}%").where.not(id: current_user.id)
+    respond_to do |format|
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
     @users = User.where('name LIKE(?)', "%#{params[:name]}%").where.not(id: current_user.id)
     respond_to do |format|
       format.json
+      format.html { redirect_to root_path }
     end
   end
 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,12 +22,7 @@
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       #chat-group-users
-        - @group.users.each do |user|
-          .chat-group-user.clearfix{id: "group-user-#{user.id}"}
-            %input{ type: "hidden", name: "group[user_ids][]", value: user.id}
-            %p.chat-group-user__name= user.name
-            - unless user.id == current_user.id
-              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn{'data-user-id': user.id} 削除
+        = render partial: "user", collection: group.users
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,6 +11,12 @@
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat_group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{for: "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{type: 'text', placeholder: "追加したいユーザー名を入力してください"}
+        #user-search-result
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
     /
       <div class='chat-group-form__field--left'>

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -17,31 +17,17 @@
       .chat-group-form__search.clearfix
         %input#user-search-field.chat-group-form__input{type: 'text', placeholder: "追加したいユーザー名を入力してください"}
         #user-search-result
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div id='chat-group-users'>
-        <div class='chat-group-user clearfix' id='chat-group-user-22'>
-        <input name='chat_group[user_ids][]' type='hidden' value='22'>
-        <p class='chat-group-user__name'>seo_kyohei</p>
-        </div>
-        </div>
+      #chat-group-users
+        - @group.users.each do |user|
+          .chat-group-user.clearfix{id: "group-user-#{user.id}"}
+            %input{ type: "hidden", name: "group[user_ids][]", value: user.id}
+            %p.chat-group-user__name= user.name
+            - unless user.id == current_user.id
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn{'data-user-id': user.id} 削除
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_user.html.haml
+++ b/app/views/groups/_user.html.haml
@@ -1,0 +1,5 @@
+.chat-group-user.clearfix{id: "group-user-#{user.id}"}
+  %input{ type: "hidden", name: "group[user_ids][]", value: user.id}
+  %p.chat-group-user__name= user.name
+  - unless user.id == current_user.id
+    %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn{'data-user-id': user.id} 削除

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end


### PR DESCRIPTION
# WHAT
ユーザーをインクリメンタルサーチできるようにする. やることは以下
  
* グループ作成/編集 時にテキストフィールドを用意して入力するたびにユーザーを検索し、その検索結果をテキストフィールドの下に表示させる  
* 検索結果で表示されたユーザーを追加/削除をクリックするとグループのメンバーが更新できるようにする

# WHY
ユーザー検索をインクリメンタルサーチ化することで、ユーザー検索の使用感が向上するから